### PR TITLE
add clipping to polylines

### DIFF
--- a/examples/clipping.rs
+++ b/examples/clipping.rs
@@ -1,7 +1,7 @@
 use bevy::{
     color::palettes::css::{BLUE, GREEN, RED},
     prelude::*,
-    render::primitives::HalfSpace,
+    render::{camera::ScalingMode, primitives::HalfSpace},
 };
 use bevy_polyline::{clipping::ClippingSettings, prelude::*};
 
@@ -43,11 +43,9 @@ fn setup(
             ],
         }),
         material: polyline_materials.add(PolylineMaterial {
-            width: 10.0,
             color: RED.into(),
-            perspective: false,
             enable_clipping: true,
-            depth_bias: 0.0,
+            ..default()
         }),
         ..default()
     });
@@ -76,11 +74,10 @@ fn setup(
             ],
         }),
         material: polyline_materials.add(PolylineMaterial {
-            width: 10.0,
             color: GREEN.into(),
             perspective: true,
             enable_clipping: true,
-            depth_bias: 0.0,
+            ..default()
         }),
         ..default()
     });
@@ -90,11 +87,9 @@ fn setup(
             vertices: vec![Vec3::NEG_ONE, Vec3::ONE],
         }),
         material: polyline_materials.add(PolylineMaterial {
-            width: 10.0,
             color: BLUE.into(),
-            perspective: false,
             enable_clipping: false,
-            depth_bias: 0.0,
+            ..default()
         }),
         ..default()
     });

--- a/examples/clipping.rs
+++ b/examples/clipping.rs
@@ -1,0 +1,75 @@
+use bevy::{color::palettes::css::RED, prelude::*, render::primitives::HalfSpace};
+use bevy_polyline::{clipping::ClippingSettings, prelude::*};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(PolylinePlugin)
+        .add_systems(Startup, setup)
+        .add_systems(Update, update_clipping)
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    mut polyline_materials: ResMut<Assets<PolylineMaterial>>,
+    mut polylines: ResMut<Assets<Polyline>>,
+) {
+    commands.spawn(PolylineBundle {
+        polyline: polylines.add(Polyline {
+            vertices: vec![
+                // bottom face
+                Vec3::new(-1.0, -1.0, -1.0),
+                Vec3::new(1.0, -1.0, -1.0),
+                Vec3::new(1.0, -1.0, 1.0),
+                Vec3::new(-1.0, -1.0, 1.0),
+                Vec3::new(-1.0, -1.0, -1.0),
+                // vertical edges
+                Vec3::new(-1.0, 1.0, -1.0),
+                Vec3::new(-1.0, 1.0, 1.0),
+                Vec3::new(-1.0, -1.0, 1.0),
+                Vec3::new(-1.0, 1.0, 1.0),
+                Vec3::new(1.0, 1.0, 1.0),
+                Vec3::new(1.0, -1.0, 1.0),
+                Vec3::new(1.0, 1.0, 1.0),
+                Vec3::new(1.0, 1.0, -1.0),
+                Vec3::new(1.0, -1.0, -1.0),
+                Vec3::new(1.0, 1.0, -1.0),
+                Vec3::new(-1.0, 1.0, -1.0),
+            ],
+        }),
+        material: polyline_materials.add(PolylineMaterial {
+            width: 10.0,
+            color: RED.into(),
+            perspective: false,
+            ..default()
+        }),
+        ..default()
+    });
+
+    // camera
+    commands.spawn(Camera3dBundle {
+        transform: Transform::from_xyz(2.5, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        camera: Camera {
+            hdr: true,
+            ..default()
+        },
+        ..default()
+    });
+}
+
+fn update_clipping(mut settings: ResMut<ClippingSettings>, time: Res<Time>) {
+    settings.clear();
+    settings.push(HalfSpace::new(Vec4::new(
+        1.0,
+        0.0,
+        1.0,
+        time.elapsed_seconds().sin() + 2.0,
+    )));
+    settings.push(HalfSpace::new(Vec4::new(
+        0.0,
+        1.0,
+        0.0,
+        time.elapsed_seconds().cos() * 0.5 + 1.0,
+    )));
+}

--- a/examples/clipping.rs
+++ b/examples/clipping.rs
@@ -1,7 +1,7 @@
 use bevy::{
     color::palettes::css::{BLUE, GREEN, RED},
     prelude::*,
-    render::{camera::ScalingMode, primitives::HalfSpace},
+    render::primitives::HalfSpace,
 };
 use bevy_polyline::{clipping::ClippingSettings, prelude::*};
 

--- a/examples/clipping.rs
+++ b/examples/clipping.rs
@@ -1,4 +1,8 @@
-use bevy::{color::palettes::css::RED, prelude::*, render::primitives::HalfSpace};
+use bevy::{
+    color::palettes::css::{BLUE, GREEN, RED},
+    prelude::*,
+    render::primitives::HalfSpace,
+};
 use bevy_polyline::{clipping::ClippingSettings, prelude::*};
 
 fn main() {
@@ -42,7 +46,55 @@ fn setup(
             width: 10.0,
             color: RED.into(),
             perspective: false,
-            ..default()
+            enable_clipping: true,
+            depth_bias: 0.0,
+        }),
+        ..default()
+    });
+
+    commands.spawn(PolylineBundle {
+        polyline: polylines.add(Polyline {
+            vertices: vec![
+                // bottom face
+                Vec3::new(-1.5, -1.5, -1.5),
+                Vec3::new(1.5, -1.5, -1.5),
+                Vec3::new(1.5, -1.5, 1.5),
+                Vec3::new(-1.5, -1.5, 1.5),
+                Vec3::new(-1.5, -1.5, -1.5),
+                // vertical edges
+                Vec3::new(-1.5, 1.5, -1.5),
+                Vec3::new(-1.5, 1.5, 1.5),
+                Vec3::new(-1.5, -1.5, 1.5),
+                Vec3::new(-1.5, 1.5, 1.5),
+                Vec3::new(1.5, 1.5, 1.5),
+                Vec3::new(1.5, -1.5, 1.5),
+                Vec3::new(1.5, 1.5, 1.5),
+                Vec3::new(1.5, 1.5, -1.5),
+                Vec3::new(1.5, -1.5, -1.5),
+                Vec3::new(1.5, 1.5, -1.5),
+                Vec3::new(-1.5, 1.5, -1.5),
+            ],
+        }),
+        material: polyline_materials.add(PolylineMaterial {
+            width: 10.0,
+            color: GREEN.into(),
+            perspective: true,
+            enable_clipping: true,
+            depth_bias: 0.0,
+        }),
+        ..default()
+    });
+
+    commands.spawn(PolylineBundle {
+        polyline: polylines.add(Polyline {
+            vertices: vec![Vec3::NEG_ONE, Vec3::ONE],
+        }),
+        material: polyline_materials.add(PolylineMaterial {
+            width: 10.0,
+            color: BLUE.into(),
+            perspective: false,
+            enable_clipping: false,
+            depth_bias: 0.0,
         }),
         ..default()
     });

--- a/examples/depth_bias.rs
+++ b/examples/depth_bias.rs
@@ -84,6 +84,7 @@ fn setup(
             color: RED.into(),
             depth_bias: -1.0,
             perspective: false,
+            ..Default::default()
         }),
         ..Default::default()
     });
@@ -101,6 +102,7 @@ fn setup(
                 color: Color::hsl((bias + 1.0) / 2.0 * 270.0, 1.0, 0.5).to_linear(),
                 depth_bias: bias,
                 perspective: false,
+                ..Default::default()
             }),
             ..Default::default()
         });

--- a/examples/linestrip.rs
+++ b/examples/linestrip.rs
@@ -37,6 +37,7 @@ fn setup(
             perspective: false,
             // Bias the line toward the camera so the line at the cube-plane intersection is visible
             depth_bias: -0.0002,
+            ..Default::default()
         }),
         ..Default::default()
     });

--- a/src/clipping.rs
+++ b/src/clipping.rs
@@ -1,0 +1,104 @@
+use bevy::{
+    prelude::*,
+    render::{
+        extract_resource::{ExtractResource, ExtractResourcePlugin},
+        primitives::HalfSpace,
+        render_resource::{
+            BindGroup, BindGroupEntries, Buffer, BufferInitDescriptor, BufferUsages,
+        },
+        renderer::RenderDevice,
+        Render, RenderApp, RenderSet,
+    },
+};
+use bytemuck::{Pod, Zeroable};
+
+use crate::material::PolylineMaterialPipeline;
+
+pub const MAX_HALF_SPACES: usize = 10;
+
+#[derive(Default)]
+pub struct PolylineClippingPlugin;
+
+impl Plugin for PolylineClippingPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<ClippingSettings>()
+            .add_plugins(ExtractResourcePlugin::<ClippingSettings>::default());
+    }
+
+    fn finish(&self, app: &mut App) {
+        if let Some(render_app) = app.get_sub_app_mut(RenderApp) {
+            render_app.add_systems(
+                Render,
+                prepare_half_spaces
+                    .in_set(RenderSet::PrepareBindGroups)
+                    .run_if(|res: Res<ClippingSettings>| res.is_changed()),
+            );
+        }
+    }
+}
+
+#[derive(Debug, Default, Resource, Clone, Deref, DerefMut)]
+pub struct ClippingSettings(Vec<HalfSpace>);
+
+impl ExtractResource for ClippingSettings {
+    type Source = ClippingSettings;
+    fn extract_resource(source: &Self::Source) -> Self {
+        source.clone()
+    }
+}
+
+#[derive(Clone, Copy, Pod, Zeroable)]
+#[repr(C)]
+struct HalfSpaceData {
+    // Make the count a vec4 to make alignment easier
+    count: [u32; 4],
+    half_spaces: [[f32; 4]; MAX_HALF_SPACES],
+}
+
+impl From<Vec<HalfSpace>> for HalfSpaceData {
+    fn from(half_spaces: Vec<HalfSpace>) -> Self {
+        let count = half_spaces.len().min(MAX_HALF_SPACES);
+
+        let mut data = HalfSpaceData {
+            count: [count as u32; 4],
+            half_spaces: [[0.0; 4]; MAX_HALF_SPACES],
+        };
+        for (i, half_space) in half_spaces.iter().take(count).enumerate() {
+            data.half_spaces[i] = half_space.normal_d().into();
+        }
+
+        data
+    }
+}
+
+#[derive(Resource)]
+pub struct HalfSpacesUniform {
+    pub buffer: Buffer,
+    pub bind_group: BindGroup,
+}
+
+pub fn prepare_half_spaces(
+    mut commands: Commands,
+    render_device: Res<RenderDevice>,
+    pipeline: Res<PolylineMaterialPipeline>,
+    clipping_settings: Res<ClippingSettings>,
+) {
+    let half_space_data: HalfSpaceData = clipping_settings.0.clone().into();
+
+    let half_spaces_buffer = render_device.create_buffer_with_data(&BufferInitDescriptor {
+        label: Some("half_spaces_buffer"),
+        contents: bytemuck::bytes_of(&half_space_data),
+        usage: BufferUsages::UNIFORM | BufferUsages::COPY_DST,
+    });
+
+    let bind_group = render_device.create_bind_group(
+        Some("half_spaces_bind_group"),
+        &pipeline.half_spaces_layout,
+        &BindGroupEntries::single(half_spaces_buffer.as_entire_binding()),
+    );
+
+    commands.insert_resource(HalfSpacesUniform {
+        buffer: half_spaces_buffer,
+        bind_group,
+    });
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,9 +2,11 @@
 #![allow(clippy::too_many_arguments)]
 
 use bevy::{asset::load_internal_asset, prelude::*};
+use clipping::PolylineClippingPlugin;
 use material::PolylineMaterialPlugin;
 use polyline::{PolylineBasePlugin, PolylineRenderPlugin};
 
+pub mod clipping;
 pub mod material;
 pub mod polyline;
 
@@ -29,6 +31,7 @@ impl Plugin for PolylinePlugin {
         app.add_plugins((
             PolylineBasePlugin,
             PolylineRenderPlugin,
+            PolylineClippingPlugin,
             PolylineMaterialPlugin,
         ));
     }

--- a/src/polyline.rs
+++ b/src/polyline.rs
@@ -273,6 +273,7 @@ bitflags::bitflags! {
         const PERSPECTIVE = (1 << 0);
         const TRANSPARENT_MAIN_PASS = (1 << 1);
         const HDR = (1 << 2);
+        const CLIPPING = (1 << 3);
         const MSAA_RESERVED_BITS = Self::MSAA_MASK_BITS << Self::MSAA_SHIFT_BITS;
     }
 }

--- a/src/shaders/polyline.wgsl
+++ b/src/shaders/polyline.wgsl
@@ -19,6 +19,14 @@ struct PolylineMaterial {
 @group(2) @binding(0)
 var<uniform> material: PolylineMaterial;
 
+struct HalfSpaces {
+    count: vec4<u32>, // Make the count a vec4, to make alignment easier
+    planes: array<vec4<f32>, 10>,
+};
+
+@group(3) @binding(0)
+var<uniform> half_spaces: HalfSpaces;
+
 struct Vertex {
     @location(0) point_a: vec3<f32>,
     @location(1) point_b: vec3<f32>,
@@ -28,6 +36,7 @@ struct Vertex {
 struct VertexOutput {
     @builtin(position) clip_position: vec4<f32>,
     @location(0) color: vec4<f32>,
+    @location(1) world_position: vec4<f32>,
 };
 
 @vertex
@@ -84,14 +93,18 @@ fn vertex(vertex: Vertex) -> VertexOutput {
         // depth * (clip.w / depth)^-depth_bias. So that when -depth_bias is 1.0, this is equal to clip.w
         // and when equal to 0.0, it is exactly equal to depth.
         // the epsilon is here to prevent the depth from exceeding clip.w when -depth_bias = 1.0
-        // clip.w represents the near plane in homogenous clip space in bevy, having a depth
+        // clip.w represents the near plane in homogeneous clip space in bevy, having a depth
         // of this value means nothing can be in front of this
         // The reason this uses an exponential function is that it makes it much easier for the
-        // user to chose a value that is convinient for them
+        // user to chose a value that is convenient for them
         depth = depth * exp2(-material.depth_bias * log2(clip.w / depth - epsilon));
     }
 
-    return VertexOutput(vec4(clip.w * ((2.0 * pt) / resolution - 1.0), depth, clip.w), color);
+    return VertexOutput(
+        vec4(clip.w * ((2.0 * pt) / resolution - 1.0), depth, clip.w), 
+        color, 
+        polyline.model * vec4(mix(vertex.point_a, vertex.point_b, position.z), 1.0),
+    );
 }
 
 fn clip_near_plane(a: vec4<f32>, b: vec4<f32>) -> vec4<f32> {
@@ -107,10 +120,20 @@ fn clip_near_plane(a: vec4<f32>, b: vec4<f32>) -> vec4<f32> {
 }
 
 struct FragmentInput {
+    @builtin(position) clip_position: vec4<f32>,
     @location(0) color: vec4<f32>,
+    @location(1) world_position: vec4<f32>,
 };
 
 @fragment
 fn fragment(in: FragmentInput) -> @location(0) vec4<f32> {
+    for(var i: u32 = 0u; i < half_spaces.count[0]; i++) {
+        let plane = half_spaces.planes[i];
+        let distance = dot(plane.xyz, in.world_position.xyz) + plane.w;
+        if (distance < 0.0) {
+            discard;
+        }
+    }
+
     return in.color;
 }

--- a/src/shaders/polyline.wgsl
+++ b/src/shaders/polyline.wgsl
@@ -127,13 +127,15 @@ struct FragmentInput {
 
 @fragment
 fn fragment(in: FragmentInput) -> @location(0) vec4<f32> {
-    for(var i: u32 = 0u; i < half_spaces.count[0]; i++) {
-        let plane = half_spaces.planes[i];
-        let distance = dot(plane.xyz, in.world_position.xyz) + plane.w;
-        if (distance < 0.0) {
-            discard;
+    #ifdef POLYLINE_CLIPPING
+        for(var i: u32 = 0u; i < half_spaces.count[0]; i++) {
+            let plane = half_spaces.planes[i];
+            let distance = dot(plane.xyz, in.world_position.xyz) + plane.w;
+            if (distance < 0.0) {
+                discard;
+            }
         }
-    }
+    #endif
 
     return in.color;
 }

--- a/src/shaders/polyline.wgsl
+++ b/src/shaders/polyline.wgsl
@@ -96,7 +96,7 @@ fn vertex(vertex: Vertex) -> VertexOutput {
         // clip.w represents the near plane in homogeneous clip space in bevy, having a depth
         // of this value means nothing can be in front of this
         // The reason this uses an exponential function is that it makes it much easier for the
-        // user to chose a value that is convenient for them
+        // user to choose a value that is convenient for them
         depth = depth * exp2(-material.depth_bias * log2(clip.w / depth - epsilon));
     }
 


### PR DESCRIPTION
This branch adds a way to clip the polylines by setting up to ten halfspaces. It wasn't possible to make the limit configurable, as wgsl / naga does not support shader defs outside of functions.

Solves #1 