### PR TITLE
No direct bevy import

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "bevy_polyline"
-version = "0.12.0"
+version = "0.12.1"
 description = "Polyline Rendering for Bevy"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/ForesightMiningSoftwareCorporation/bevy_polyline"
@@ -18,11 +18,17 @@ authors = [
 
 [dependencies]
 bitflags = "2.3"
-bevy = { version = "0.16", default-features = false, features = [
-    "bevy_core_pipeline",
-    "bevy_render",
-    "bevy_asset",
-] }
+bevy_app = { version = "0.16.0", default-features = false }
+bevy_asset = { version = "0.16.0", default-features = false }
+bevy_color = { version = "0.16.0", default-features = false }
+bevy_core_pipeline = { version = "0.16.0", default-features = false }
+bevy_derive = { version = "0.16.0", default-features = false }
+bevy_ecs = { version = "0.16.0", default-features = false }
+bevy_image = { version = "0.16.0", default-features = false }
+bevy_math = { version = "0.16.0", default-features = false }
+bevy_reflect = { version = "0.16.0", default-features = false }
+bevy_render = { version = "0.16.0", default-features = false }
+bevy_transform = { version = "0.16.0", default-features = false }
 bytemuck = "1.16.1"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ We intend to track the `main` branch of Bevy. PRs supporting this are welcome!
 
 | bevy | bevy_polyline |
 | ---- | ------------- |
-| 0.15 | 0.12          |
+| 0.16 | 0.12          |
 | 0.15 | 0.11          |
 | 0.14 | 0.10          |
 | 0.13 | 0.9           |

--- a/src/clipping.rs
+++ b/src/clipping.rs
@@ -1,14 +1,12 @@
-use bevy::{
-    prelude::*,
-    render::{
-        extract_resource::{ExtractResource, ExtractResourcePlugin},
-        primitives::HalfSpace,
-        render_resource::{
-            BindGroup, BindGroupEntries, Buffer, BufferInitDescriptor, BufferUsages,
-        },
-        renderer::RenderDevice,
-        Render, RenderApp, RenderSet,
-    },
+use bevy_app::{App, Plugin};
+use bevy_derive::{Deref, DerefMut};
+use bevy_ecs::prelude::*;
+use bevy_render::{
+    extract_resource::{ExtractResource, ExtractResourcePlugin},
+    primitives::HalfSpace,
+    render_resource::{BindGroup, BindGroupEntries, Buffer, BufferInitDescriptor, BufferUsages},
+    renderer::RenderDevice,
+    Render, RenderApp, RenderSet,
 };
 use bytemuck::{Pod, Zeroable};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,9 @@
 #![allow(clippy::type_complexity)]
 #![allow(clippy::too_many_arguments)]
 
-use bevy::{
-    asset::{load_internal_asset, weak_handle},
-    prelude::*,
-};
+use bevy_app::{App, Plugin};
+use bevy_asset::{load_internal_asset, weak_handle, Handle};
+use bevy_render::render_resource::Shader;
 use clipping::PolylineClippingPlugin;
 use material::PolylineMaterialPlugin;
 use polyline::{PolylineBasePlugin, PolylineRenderPlugin};
@@ -23,7 +22,7 @@ pub struct PolylinePlugin;
 pub const SHADER_HANDLE: Handle<Shader> = weak_handle!("b180bfe9-10c8-48fe-b27a-dfa41436d7d0");
 
 impl Plugin for PolylinePlugin {
-    fn build(&self, app: &mut bevy::prelude::App) {
+    fn build(&self, app: &mut App) {
         load_internal_asset!(
             app,
             SHADER_HANDLE,

--- a/src/material.rs
+++ b/src/material.rs
@@ -5,30 +5,33 @@ use crate::{
         PolylineViewBindGroup, SetPolylineBindGroup,
     },
 };
-
-use bevy::{
-    core_pipeline::{
-        core_3d::{AlphaMask3d, Opaque3d, Opaque3dBatchSetKey, Opaque3dBinKey, Transparent3d},
-        prepass::{OpaqueNoLightmap3dBatchSetKey, OpaqueNoLightmap3dBinKey},
-    },
-    ecs::{
-        component::Tick,
-        query::ROQueryItem,
-        system::{
-            lifetimeless::{Read, SRes},
-            SystemParamItem,
-        },
-    },
+use bevy_app::prelude::*;
+use bevy_asset::prelude::*;
+use bevy_color::prelude::*;
+use bevy_core_pipeline::{
+    core_3d::{AlphaMask3d, Opaque3d, Opaque3dBatchSetKey, Opaque3dBinKey, Transparent3d},
+    prepass::{OpaqueNoLightmap3dBatchSetKey, OpaqueNoLightmap3dBinKey},
+};
+use bevy_ecs::{
+    component::Tick,
     prelude::*,
-    render::{
-        extract_component::{ExtractComponent, ExtractComponentPlugin},
-        render_asset::{PrepareAssetError, RenderAsset, RenderAssetPlugin, RenderAssets},
-        render_phase::*,
-        render_resource::{binding_types::uniform_buffer, *},
-        renderer::{RenderDevice, RenderQueue},
-        view::{ExtractedView, RenderVisibleEntities, ViewUniformOffset},
-        Render, RenderApp, RenderSet,
+    query::ROQueryItem,
+    system::{
+        lifetimeless::{Read, SRes},
+        SystemParamItem,
     },
+};
+use bevy_math::Vec4;
+use bevy_reflect::prelude::*;
+use bevy_render::{
+    extract_component::{ExtractComponent, ExtractComponentPlugin},
+    mesh::Mesh,
+    render_asset::{PrepareAssetError, RenderAsset, RenderAssetPlugin, RenderAssets},
+    render_phase::*,
+    render_resource::{binding_types::uniform_buffer, *},
+    renderer::{RenderDevice, RenderQueue},
+    view::{ExtractedView, Msaa, RenderVisibleEntities, ViewUniformOffset},
+    Render, RenderApp, RenderSet,
 };
 use std::fmt::Debug;
 
@@ -135,7 +138,7 @@ impl RenderAsset for GpuPolylineMaterial {
     fn prepare_asset(
         polyline_material: Self::SourceAsset,
         _: AssetId<Self::SourceAsset>,
-        (device, queue, polyline_pipeline): &mut bevy::ecs::system::SystemParamItem<Self::Param>,
+        (device, queue, polyline_pipeline): &mut bevy_ecs::system::SystemParamItem<Self::Param>,
     ) -> Result<Self, PrepareAssetError<Self::SourceAsset>> {
         let value = PolylineMaterialUniform {
             width: polyline_material.width,
@@ -396,7 +399,7 @@ pub fn queue_material_polylines(
                             draw_function: draw_opaque,
                             material_bind_group_index: None,
                             lightmap_slab: None,
-                            vertex_slab: default(),
+                            vertex_slab: Default::default(),
                             index_slab: None,
                         },
                         Opaque3dBinKey {
@@ -415,7 +418,7 @@ pub fn queue_material_polylines(
                             draw_function: draw_alpha_mask,
                             pipeline: pipeline_id,
                             material_bind_group_index: None,
-                            vertex_slab: default(),
+                            vertex_slab: Default::default(),
                             index_slab: None,
                         },
                         OpaqueNoLightmap3dBinKey {

--- a/src/polyline.rs
+++ b/src/polyline.rs
@@ -1,25 +1,29 @@
 use crate::material::PolylineMaterialHandle;
-use bevy::{
-    ecs::{
-        query::ROQueryItem,
-        system::{
-            lifetimeless::{Read, SRes},
-            SystemParamItem,
-        },
-    },
+use bevy_app::{App, Plugin};
+use bevy_asset::{Asset, AssetApp, AssetId, Handle};
+use bevy_ecs::{
     prelude::*,
-    reflect::TypePath,
-    render::{
-        extract_component::{ComponentUniforms, DynamicUniformIndex, UniformComponentPlugin},
-        render_asset::{PrepareAssetError, RenderAsset, RenderAssetPlugin, RenderAssets},
-        render_phase::{PhaseItem, RenderCommand, RenderCommandResult, TrackedRenderPass},
-        render_resource::{binding_types::uniform_buffer, *},
-        renderer::RenderDevice,
-        sync_world::{RenderEntity, SyncToRenderWorld},
-        view::{self, ViewUniform, ViewUniforms, VisibilityClass},
-        Extract, Render, RenderApp, RenderSet,
+    query::ROQueryItem,
+    system::{
+        lifetimeless::{Read, SRes},
+        SystemParamItem,
     },
 };
+use bevy_image::BevyDefault;
+use bevy_math::{Mat4, Vec3};
+use bevy_reflect::TypePath;
+use bevy_render::{
+    extract_component::{ComponentUniforms, DynamicUniformIndex, UniformComponentPlugin},
+    prelude::*,
+    render_asset::{PrepareAssetError, RenderAsset, RenderAssetPlugin, RenderAssets},
+    render_phase::{PhaseItem, RenderCommand, RenderCommandResult, TrackedRenderPass},
+    render_resource::{binding_types::uniform_buffer, *},
+    renderer::RenderDevice,
+    sync_world::{RenderEntity, SyncToRenderWorld},
+    view::{self, ViewUniform, ViewUniforms, VisibilityClass},
+    Extract, Render, RenderApp, RenderSet,
+};
+use bevy_transform::components::{GlobalTransform, Transform};
 
 pub struct PolylineBasePlugin;
 
@@ -81,7 +85,7 @@ impl RenderAsset for GpuPolyline {
     fn prepare_asset(
         polyline: Self::SourceAsset,
         _: AssetId<Self::SourceAsset>,
-        render_device: &mut bevy::ecs::system::SystemParamItem<Self::Param>,
+        render_device: &mut bevy_ecs::system::SystemParamItem<Self::Param>,
     ) -> Result<Self, PrepareAssetError<Self::SourceAsset>> {
         let vertex_buffer_data = bytemuck::cast_slice(polyline.vertices.as_slice());
         let vertex_buffer = render_device.create_buffer_with_data(&BufferInitDescriptor {
@@ -204,7 +208,7 @@ impl SpecializedRenderPipeline for PolylinePipeline {
         }
 
         let format = match key.contains(PolylinePipelineKey::HDR) {
-            true => bevy::render::view::ViewTarget::TEXTURE_FORMAT_HDR,
+            true => bevy_render::view::ViewTarget::TEXTURE_FORMAT_HDR,
             false => TextureFormat::bevy_default(),
         };
 
@@ -347,7 +351,7 @@ pub fn prepare_polyline_view_bind_groups(
     render_device: Res<RenderDevice>,
     polyline_pipeline: Res<PolylinePipeline>,
     view_uniforms: Res<ViewUniforms>,
-    views: Query<Entity, With<bevy::render::view::ExtractedView>>,
+    views: Query<Entity, With<bevy_render::view::ExtractedView>>,
 ) {
     for entity in views.iter() {
         let view_bind_group = render_device.create_bind_group(


### PR DESCRIPTION
This PR replaces the direct import of bevy with only the required bevy crates.
Reduces crates from 725 to 606
