### PR TITLE
Update to Bevy 0.19 and wgpu 29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "bevy_polyline"
-version = "0.14.0"
+version = "0.15.0"
 description = "Polyline Rendering for Bevy"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/ForesightMiningSoftwareCorporation/bevy_polyline"
@@ -17,26 +17,25 @@ authors = [
 ]
 
 [dependencies]
-bevy_app = "0.18"
-bevy_asset = "0.18"
-bevy_camera = "0.18"
-bevy_color = "0.18"
-bevy_core_pipeline = "0.18"
-bevy_derive = "0.18"
-bevy_ecs = "0.18"
-bevy_image = "0.18"
-bevy_math = "0.18"
-bevy_mesh = "0.18"
-bevy_post_process = "0.18"
-bevy_reflect = "0.18"
-bevy_render = "0.18"
-bevy_shader = "0.18"
-bevy_transform = "0.18"
+bevy_app = "0.19"
+bevy_asset = "0.19"
+bevy_camera = "0.19"
+bevy_color = "0.19"
+bevy_core_pipeline = "0.19"
+bevy_derive = "0.19"
+bevy_ecs = "0.19"
+bevy_math = "0.19"
+bevy_mesh = "0.19"
+bevy_post_process = "0.19"
+bevy_reflect = "0.19"
+bevy_render = "0.19"
+bevy_shader = "0.19"
+bevy_transform = "0.19"
 bitflags = "2.3"
 bytemuck = "1.16.1"
 
 [dev-dependencies]
-bevy = { version = "0.18", default-features = false, features = [
+bevy = { version = "0.19", default-features = false, features = [
   "bevy_pbr",
   "bevy_window",
   "bevy_winit",
@@ -48,8 +47,3 @@ bevy = { version = "0.18", default-features = false, features = [
 lazy_static = "1.4.0"
 rand = "0.8.4"
 ringbuffer = "0.15"
-
-[patch.crates-io]
-# Unify the windows crate version to avoid DX12 type mismatches in wgpu-hal.
-windows = { git = "https://github.com/microsoft/windows-rs", tag = "0.58.0" }
-windows-core = { git = "https://github.com/microsoft/windows-rs", tag = "0.58.0" }

--- a/examples/clipping.rs
+++ b/examples/clipping.rs
@@ -1,10 +1,9 @@
 use bevy::{
-    camera::primitives::HalfSpace,
     color::palettes::css::{BLUE, GREEN, RED},
     prelude::*,
 };
+use bevy_camera::Hdr;
 use bevy_polyline::{clipping::ClippingSettings, prelude::*};
-use bevy_render::view::Hdr;
 
 fn main() {
     App::new()

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -1,4 +1,5 @@
-use bevy::{color::palettes::css::RED, prelude::*, render::view::Hdr};
+use bevy::{color::palettes::css::RED, prelude::*};
+use bevy_camera::Hdr;
 use bevy_polyline::prelude::*;
 
 fn main() {

--- a/examples/nbody.rs
+++ b/examples/nbody.rs
@@ -5,8 +5,8 @@ use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     math::Vec3A,
     prelude::*,
-    render::view::Hdr,
 };
+use bevy_camera::Hdr;
 use bevy_polyline::prelude::*;
 use bevy_post_process::bloom::Bloom;
 

--- a/examples/perspective.rs
+++ b/examples/perspective.rs
@@ -1,4 +1,5 @@
-use bevy::{color::palettes::css::RED, prelude::*, render::view::Hdr};
+use bevy::{color::palettes::css::RED, prelude::*};
+use bevy_camera::Hdr;
 use bevy_polyline::prelude::*;
 
 fn main() {

--- a/src/clipping.rs
+++ b/src/clipping.rs
@@ -1,7 +1,7 @@
 use bevy_app::{App, Plugin};
-use bevy_camera::primitives::HalfSpace;
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::prelude::*;
+use bevy_math::primitives::HalfSpace;
 use bevy_render::{
     extract_resource::{ExtractResource, ExtractResourcePlugin},
     render_resource::{

--- a/src/material.rs
+++ b/src/material.rs
@@ -10,18 +10,20 @@ use bevy_app::{App, Plugin};
 use bevy_asset::{Asset, AssetApp, AssetId, Handle};
 use bevy_color::{Alpha, Color, ColorToComponents, LinearRgba};
 use bevy_core_pipeline::{
-    core_3d::{AlphaMask3d, Opaque3d, Opaque3dBatchSetKey, Opaque3dBinKey, Transparent3d},
+    core_3d::{
+        AlphaMask3d, Opaque3d, Opaque3dBatchSetKey, Opaque3dBinKey, Transparent3d,
+        TransparentSortingInfo3d,
+    },
     prepass::{OpaqueNoLightmap3dBatchSetKey, OpaqueNoLightmap3dBinKey},
 };
 use bevy_ecs::{
-    change_detection::Tick,
     component::Component,
     query::ROQueryItem,
     resource::Resource,
     schedule::IntoScheduleConfigs,
     system::{
         lifetimeless::{Read, SRes},
-        Local, Query, Res, ResMut, SystemParamItem,
+        Query, Res, ResMut, SystemParamItem,
     },
     world::{FromWorld, World},
 };
@@ -338,7 +340,6 @@ pub fn queue_material_polylines(
     mut opaque_phases: ResMut<ViewBinnedRenderPhases<Opaque3d>>,
     mut alpha_mask_phases: ResMut<ViewBinnedRenderPhases<AlphaMask3d>>,
     mut transparent_phases: ResMut<ViewSortedRenderPhases<Transparent3d>>,
-    mut next_tick: Local<Tick>,
 ) {
     let draw_opaque = opaque_draw_functions.read().id::<DrawPolylineMaterial>();
     let draw_alpha_mask = alpha_mask_draw_functions
@@ -349,12 +350,12 @@ pub fn queue_material_polylines(
         .id::<DrawPolylineMaterial>();
 
     for (view, visible_entities, msaa) in &views {
-        let inverse_view_matrix = view.world_from_view.to_matrix().inverse();
-        let inverse_view_row_2 = inverse_view_matrix.row(2);
-
         let mut polyline_key = PolylinePipelineKey::from_msaa_samples(msaa.samples());
-        polyline_key |= PolylinePipelineKey::from_hdr(view.hdr);
-        for (visible_entity, visible_main_entity) in visible_entities.get::<PolylineHandle>() {
+        polyline_key |= PolylinePipelineKey::from_target_format(view.target_format);
+        let Some(visible_polylines) = visible_entities.get::<PolylineHandle>() else {
+            continue;
+        };
+        for (visible_entity, visible_main_entity) in visible_polylines.iter_visible() {
             let Ok((material_handle, polyline_uniform)) = material_meshes.get(*visible_entity)
             else {
                 continue;
@@ -382,9 +383,6 @@ pub fn queue_material_polylines(
                 continue;
             };
 
-            let this_tick = next_tick.get() + 1;
-            next_tick.set(this_tick);
-
             match material.alpha_mode {
                 AlphaMode::Opaque => {
                     opaque_phase.add(
@@ -393,8 +391,7 @@ pub fn queue_material_polylines(
                             draw_function: draw_opaque,
                             material_bind_group_index: None,
                             lightmap_slab: None,
-                            vertex_slab: Default::default(),
-                            index_slab: None,
+                            slabs: Default::default(),
                         },
                         Opaque3dBinKey {
                             // The draw command doesn't use a mesh handle so we don't need an `asset_id`
@@ -403,7 +400,6 @@ pub fn queue_material_polylines(
                         (*visible_entity, *visible_main_entity),
                         InputUniformIndex::default(),
                         BinnedRenderPhaseType::NonMesh,
-                        *next_tick,
                     );
                 }
                 AlphaMode::Mask(_) => {
@@ -412,8 +408,7 @@ pub fn queue_material_polylines(
                             draw_function: draw_alpha_mask,
                             pipeline: pipeline_id,
                             material_bind_group_index: None,
-                            vertex_slab: Default::default(),
-                            index_slab: None,
+                            slabs: Default::default(),
                         },
                         OpaqueNoLightmap3dBinKey {
                             asset_id: AssetId::<Mesh>::invalid().untyped(),
@@ -421,25 +416,25 @@ pub fn queue_material_polylines(
                         (*visible_entity, *visible_main_entity),
                         InputUniformIndex::default(),
                         BinnedRenderPhaseType::NonMesh,
-                        *next_tick,
                     );
                 }
                 AlphaMode::Blend
                 | AlphaMode::Premultiplied
                 | AlphaMode::Add
                 | AlphaMode::Multiply => {
-                    // NOTE: row 2 of the inverse view matrix dotted with column 3 of the model matrix
-                    // gives the z component of translation of the mesh in view space
-                    let polyline_z = inverse_view_row_2.dot(polyline_uniform.transform.col(3));
-                    transparent_phase.add(Transparent3d {
+                    // `distance` is recomputed by the engine from `sorting_info`;
+                    // hand it the polyline's world-space center (model-matrix column 3).
+                    let mesh_center = polyline_uniform.transform.col(3).truncate();
+                    transparent_phase.add_transient(Transparent3d {
+                        sorting_info: TransparentSortingInfo3d::Sorted {
+                            mesh_center,
+                            depth_bias: 0.0,
+                        },
                         entity: (*visible_entity, *visible_main_entity),
                         draw_function: draw_transparent,
                         pipeline: pipeline_id,
-                        // NOTE: Back-to-front ordering for transparent with ascending sort means far should have the
-                        // lowest sort key and getting closer should increase. As we have
-                        // -z in front of the camera, the largest distance is -far with values increasing toward the
-                        // camera. As such we can just use mesh_z as the distance
-                        distance: polyline_z,
+                        // Filled in by `recalculate_sort_keys`.
+                        distance: 0.0,
                         batch_range: 0..1,
                         extra_index: PhaseItemExtraIndex::None,
                         indexed: false,

--- a/src/polyline.rs
+++ b/src/polyline.rs
@@ -10,7 +10,6 @@ use bevy_ecs::{
         SystemParamItem,
     },
 };
-use bevy_image::BevyDefault;
 use bevy_math::{Mat4, Vec3};
 use bevy_mesh::VertexBufferLayout;
 use bevy_reflect::TypePath;
@@ -210,10 +209,7 @@ impl SpecializedRenderPipeline for PolylinePipeline {
             depth_write_enabled = true;
         }
 
-        let format = match key.contains(PolylinePipelineKey::HDR) {
-            true => bevy_render::view::ViewTarget::TEXTURE_FORMAT_HDR,
-            false => TextureFormat::bevy_default(),
-        };
+        let format = key.target_format();
 
         let mut vertex_layout = VertexBufferLayout {
             step_mode: VertexStepMode::Instance,
@@ -257,8 +253,8 @@ impl SpecializedRenderPipeline for PolylinePipeline {
             },
             depth_stencil: Some(DepthStencilState {
                 format: TextureFormat::Depth32Float,
-                depth_write_enabled,
-                depth_compare: CompareFunction::Greater,
+                depth_write_enabled: Some(depth_write_enabled),
+                depth_compare: Some(CompareFunction::Greater),
                 stencil: StencilState {
                     front: StencilFaceState::IGNORE,
                     back: StencilFaceState::IGNORE,
@@ -277,7 +273,7 @@ impl SpecializedRenderPipeline for PolylinePipeline {
                 alpha_to_coverage_enabled: false,
             },
             label: Some(label),
-            push_constant_ranges: vec![],
+            immediate_size: 0,
             zero_initialize_workgroup_memory: true,
         }
     }
@@ -292,8 +288,10 @@ bitflags::bitflags! {
         const NONE = 0;
         const PERSPECTIVE = (1 << 0);
         const TRANSPARENT_MAIN_PASS = (1 << 1);
-        const HDR = (1 << 2);
         const CLIPPING = (1 << 3);
+        // Color target format: 5 bits, clear of the flag bits (0, 1, 3) and the MSAA bits (top 3).
+        const COLOR_TARGET_FORMAT_RESERVED_BITS =
+            Self::COLOR_TARGET_FORMAT_MASK_BITS << Self::COLOR_TARGET_FORMAT_SHIFT_BITS;
         const MSAA_RESERVED_BITS = Self::MSAA_MASK_BITS << Self::MSAA_SHIFT_BITS;
     }
 }
@@ -301,6 +299,9 @@ bitflags::bitflags! {
 impl PolylinePipelineKey {
     const MSAA_MASK_BITS: u32 = 0b111;
     const MSAA_SHIFT_BITS: u32 = 32 - Self::MSAA_MASK_BITS.count_ones();
+
+    const COLOR_TARGET_FORMAT_MASK_BITS: u32 = bevy_render::view::COLOR_TARGET_FORMAT_MASK_BITS;
+    const COLOR_TARGET_FORMAT_SHIFT_BITS: u32 = 4;
 
     pub fn from_msaa_samples(msaa_samples: u32) -> Self {
         let msaa_bits =
@@ -312,12 +313,23 @@ impl PolylinePipelineKey {
         1 << ((self.bits() >> Self::MSAA_SHIFT_BITS) & Self::MSAA_MASK_BITS)
     }
 
-    pub fn from_hdr(hdr: bool) -> Self {
-        if hdr {
-            PolylinePipelineKey::HDR
-        } else {
-            PolylinePipelineKey::NONE
-        }
+    /// Encode the view's color target [`TextureFormat`] into the key.
+    pub fn from_target_format(format: TextureFormat) -> Self {
+        let code = bevy_render::view::texture_format_to_code(format)
+            .expect("texture format is not supported by the polyline pipeline")
+            as u32;
+        Self::from_bits_retain(
+            (code & Self::COLOR_TARGET_FORMAT_MASK_BITS) << Self::COLOR_TARGET_FORMAT_SHIFT_BITS,
+        )
+    }
+
+    /// Decode the color target [`TextureFormat`] previously encoded with
+    /// [`Self::from_target_format`].
+    pub fn target_format(&self) -> TextureFormat {
+        let code = ((self.bits() >> Self::COLOR_TARGET_FORMAT_SHIFT_BITS)
+            & Self::COLOR_TARGET_FORMAT_MASK_BITS) as u8;
+        bevy_render::view::texture_format_from_code(code)
+            .expect("unknown color target format bits in polyline pipeline key")
     }
 }
 


### PR DESCRIPTION
## Update to Bevy 0.19 + wgpu 29

Bumps all `bevy_*` dependencies `0.18 → 0.19` and migrates the custom render pipeline to the wgpu 29 / Bevy 0.19 render API. Needed so bimplan can move to Bevy 0.19.

### Render pipeline migration
- **Pipeline descriptor (wgpu 29):** `push_constant_ranges` → `immediate_size`; `DepthStencilState::depth_write_enabled` / `depth_compare` are now `Option`.
- **View target format in the pipeline key:** replaced the HDR bool (`ExtractedView::hdr` was removed) by carrying the view's real render-target format through `PolylinePipelineKey`, encoded/decoded with `bevy_render`'s public `texture_format_to_code` / `texture_format_from_code` (mirrors upstream `MeshPipelineKey::from_target_format`). The 5-bit format region sits clear of the existing flag bits (0/1/3) and the MSAA bits.
- **Transparent3d:** `SortedRenderPhase::add` was removed → `add_transient` + the new required `TransparentSortingInfo3d`. Sorts by the polyline's world-space origin (model-matrix translation), preserving the previous back-to-front behavior.
- **Misc 0.19 breaks:** `RenderVisibleEntities::get` → `iter_visible`; merged batch-set `vertex_slab`/`index_slab` → `slabs`; binned-phase `add` signature (dropped the change-tick arg); `HalfSpace` moved to `bevy_math::primitives`.

### Dependency changes
- Removed the now-unused `bevy_image` dependency (its only use, `bevy_default()`, was eliminated by the format-key rework).
- Dropped the `windows-rs 0.58` `[patch.crates-io]` pin — it conflicts with the windows-rs version required by wgpu 29.

### Verification
- ✅ `cargo check --lib` and `cargo clippy --lib` are **green** on Rust stable (1.96; Bevy 0.19 requires ≥ 1.95).
- ⚠️ **Not yet exercised:** runtime rendering / WGSL pipeline specialization, and example crates. `cargo check` cannot catch shader or pipeline-spec errors — a render smoke-test is recommended before relying on this.
- ⚠️ **Windows/DX12:** the windows-rs patch removal was made on macOS; Windows DX12 builds with wgpu 29 should be validated.

Scope is intentionally limited to what the upgrade requires — no unrelated cleanup or reformatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
